### PR TITLE
Add missing python packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ pip install breathe
 pip install myst-parser
 pip install sphinxcontrib-jquery
 pip install sphinx-copybutton
+pip install reuse
+pip install sphinxcontrib-mermaid
 ```
 
 Now build the project "Sphinx" from the command line or IDE.


### PR DESCRIPTION
Building the tutorial website is currently failing if the sphinxcontrib-mermaid python package is not installed. Steps to trigger the bug in Windows:
```
> python -m venv sphinx-env
> cd .\build\ 
> ..\sphinx-env\Scripts\Activate.ps1
> pip install sphinx
> pip install breathe
> pip install myst-parser
> pip install sphinxcontrib-jquery
> pip install sphinx-copybutton
> cmake ..\OpenXR-Tutorials\ -DXR_TUTORIAL_BUILD_DOCUMENTATION=ON
...
> cmake --build .
MSBuild version 17.5.1+f6fdcf537 for .NET Framework

  Checking File Globs
  1>Checking Build System
  Generating documentation with Sphinx
  Running Sphinx v7.2.6
  openxr_tutorials_git_tag_py is v0.0.0
  
CUSTOMBUILD : Extension error :  [<workspace>\build\tutorial\Sphinx.vcxproj]
  Could not import extension sphinxcontrib.mermaid (exception: No module named 'sphinxcontrib.mermaid')
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(247,5): error MSB8066: Custom build for
 '<workspace>\build\CMakeFiles\458dbb8ce29aba255b5772b3d1c10f0e\Sphinx.rule;<workspace>\OpenXR-Tutorials\tutorial\CMakeLists.txt' exited with code 2. [<workspace>\build\tutorial\Sphinx.vcxproj] 
```

Added sphinxcontrib-mermaid python package to tutorial website build instructions. Did the same with reuse as it is also used.