### PR TITLE
Fix DX hang and added safety check

### DIFF
--- a/Common/GraphicsAPI_D3D11.cpp
+++ b/Common/GraphicsAPI_D3D11.cpp
@@ -203,15 +203,17 @@ GraphicsAPI_D3D11::GraphicsAPI_D3D11(XrInstance m_xrInstance, XrSystemId systemI
 
     D3D11_CHECK(CreateDXGIFactory1(IID_PPV_ARGS(&factory)), "Failed to create DXGI factory.");
 
-    UINT i = 0;
     IDXGIAdapter *adapter = nullptr;
     DXGI_ADAPTER_DESC adapterDesc = {};
-    while (factory->EnumAdapters(i, &adapter) != DXGI_ERROR_NOT_FOUND) {
+    for(UINT i = 0; factory->EnumAdapters(i, &adapter) != DXGI_ERROR_NOT_FOUND; ++i) {
         adapter->GetDesc(&adapterDesc);
         if (memcmp(&graphicsRequirements.adapterLuid, &adapterDesc.AdapterLuid, sizeof(LUID)) == 0) {
             break;  // We have the matching adapter that OpenXR wants.
         }
+        // If we don't get a match reset adapter to nullptr to force a throw.
+        adapter = nullptr;
     }
+    OPENXR_CHECK(adapter != nullptr ? XR_SUCCESS : XR_ERROR_VALIDATION_FAILURE, "Failed to find matching graphics adapter from xrGetD3D11GraphicsRequirementsKHR.");
 
     D3D11_CHECK(D3D11CreateDevice(adapter, D3D_DRIVER_TYPE_UNKNOWN, 0, D3D11_CREATE_DEVICE_DEBUG, &graphicsRequirements.minFeatureLevel, 1, D3D11_SDK_VERSION, &device, nullptr, &immediateContext), "Failed to create D3D11 Device.");
 


### PR DESCRIPTION
If using DX11 or DX12 on a machine with multiple graphics adapters (laptop with iGPU & dGPU) and the first adapter that `EnumAdapters` returns is the iGPU when OXR is expecting the dGPU; the application hangs infinitely. Mostly due to the oversight of forgetting to increment `i` each iteration of the while.

To prevent this hang entirely I've swapped the `while` out in favour of a `for` loop and added a small check underneath to throw if the adapter OXR wants isn't found by DX.