### PR TITLE
Reword tutorial setup chapter

### DIFF
--- a/tutorial/2-setup.rst
+++ b/tutorial/2-setup.rst
@@ -89,7 +89,7 @@ This structure allows you to specify both the name and the version for your appl
 
 .. _instanceextensions:
 
-Similarly to Vulkan, OpenXR allows applications to extend functionality past what is provided by the core specification. The added functionality could be hardware/vendor specific. Most vital of course is which Graphics API to use with OpenXR. OpenXR supports D3D11, D3D12, Vulkan, OpenGL and OpenGL ES. Due to the extensible nature of specification, it allows newer Graphics APIs and hardware functionality to be added with ease. Following on from the previous code in the ``CreateInstance()`` method, add the following:
+Similarly to Vulkan, OpenXR allows applications to extend functionality past what is provided by the core specification. The added functionality could be hardware/vendor specific. Most vital of course is which Graphics API to use with OpenXR. OpenXR supports D3D11, D3D12, Vulkan, OpenGL and OpenGL ES. Due to the extensible nature of the specification, it allows newer Graphics APIs and hardware functionality to be added with ease. Following on from the previous code in the ``CreateInstance()`` method, add the following:
 
 .. literalinclude:: ../Chapter2/main.cpp
 	:language: cpp
@@ -115,9 +115,7 @@ In OpenXR, we provide an explicit input capacity to both :openxr_ref:`xrEnumerat
 
 	This is a subtle difference here from the two-call idiom in the Vulkan API.
 
-Note the ``m_activeAPILayers`` and ``m_activeInstanceExtensions`` are of type ``std::vector<const char *>``. This will help us when fill out the next structure :openxr_ref:`XrInstanceCreateInfo`.
-
-Now that we've assembled all of the information needed we will fill the :openxr_ref:`XrInstanceCreateInfo` structure, and add the following to the ``CreateInstance()`` method.
+Note that ``m_activeAPILayers`` and ``m_activeInstanceExtensions`` are of type ``std::vector<const char *>``, which is helpful when filling :openxr_ref:`XrInstanceCreateInfo`. We can do just that since we have assembled all of the necessary information. Add the following to the ``CreateInstance()`` method.
 
 .. literalinclude:: ../Chapter2/main.cpp
 	:language: cpp
@@ -148,7 +146,7 @@ Here, we have initialized the :openxr_ref:`XrInstanceProperties` with the correc
 2.1.2 XR_EXT_debug_utils
 ========================
 
-XR_EXT_debug_utils is an instance extension for OpenXR, which allows the application to get more information on errors, warnings and messages raised by the runtime. You can specify which message severities and types will checked. If a debug message is raised, it is passed to the callback function, which can optionally use the user data pointer provided in the :openxr_ref:`XrDebugUtilsMessengerCreateInfoEXT` structure.
+XR_EXT_debug_utils is an instance extension for OpenXR, which allows the application to get more information on errors, warnings and messages raised by the runtime. You can specify which message severities and types are checked. If a debug message is raised, it is passed to the callback function, which can optionally use the user data pointer provided in the :openxr_ref:`XrDebugUtilsMessengerCreateInfoEXT` structure.
 
 The message severities are:
  * Verbose: Output all messages.
@@ -178,14 +176,14 @@ Copy the following code into ``CreateDebugMessenger()`` and ``DestroyDebugMessen
 	:end-before: XR_DOCS_TAG_END_DestroyDebugMessenger
 	:dedent: 8
 
-In the above, we first check that ``XR_EXT_DEBUG_UTILS_EXTENSION_NAME`` or :openxr_ref:`XR_EXT_debug_utils` is in ``activeInstanceExtensions``, which we used to create the :openxr_ref:`XrInstance`. Next, we call the ``CreateOpenXRDebugUtilsMessenger()`` function. At the end of the application, we call ``DestroyOpenXRDebugUtilsMessenger()`` to release the resource.
+In the above code, we first check that ``XR_EXT_DEBUG_UTILS_EXTENSION_NAME`` or :openxr_ref:`XR_EXT_debug_utils` is in ``activeInstanceExtensions``, which we used to create the :openxr_ref:`XrInstance`. Next, we call the ``CreateOpenXRDebugUtilsMessenger()`` function. At the end of the application, we call ``DestroyOpenXRDebugUtilsMessenger()`` to release the resource.
 
 Another feature of OpenXR is the API Layers, which may also assist you in debugging. You can read more about them in :ref:`Chapter 6.3 <6.3 OpenXR API Layers>`.
 
 2.1.3 Obtaining the System Id
 =============================
 
-The next object we want to get is the :openxr_ref:`XrSystemId`. According to `System <https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#system>`_ in the OpenXR spec, OpenXR 'separates the concept of physical systems of XR devices from the logical objects that applications interact with directly. A system represents a collection of related devices in the runtime, often made up of several individual hardware components working together to enable XR experiences. So, an :openxr_ref:`XrSystemId` could represent a VR headset and a pair of controllers, or perhaps a mobile device with video pass-through for AR. So we need to decide what type of :openxr_ref:`XrFormFactor` we want to use, as some runtimes support multiple form factors. Here, we are selecting ``XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY``. OpenXR currently offers two options for the :openxr_ref:`XrFormFactor`:
+The next object we want to get is the :openxr_ref:`XrSystemId`. According to `System <https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#system>`_ in the OpenXR spec, OpenXR *separates the concept of physical systems of XR devices from the logical objects that applications interact with directly. A system represents a collection of related devices in the runtime, often made up of several individual hardware components working together to enable XR experiences*. So, an :openxr_ref:`XrSystemId` could represent a VR headset and a pair of controllers, or perhaps a mobile device with video pass-through for AR. So we need to decide what type of :openxr_ref:`XrFormFactor` we want to use, as some runtimes support multiple form factors. Here, we are selecting ``XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY``. OpenXR currently offers two options for the :openxr_ref:`XrFormFactor`:
 
 .. literalinclude:: ../build/_deps/openxr-build/include/openxr/openxr.h
 	:language: cpp
@@ -202,7 +200,7 @@ Add the following code to the ``GetSystemID()`` method:
 	:end-before: XR_DOCS_TAG_END_GetSystemID
 	:dedent: 8
 
-Here, we have filled out the :openxr_ref:`XrSystemGetInfo` structure with the desired :openxr_ref:`XrFormFactor` and passed it as a pointer along with the :openxr_ref:`XrInstance` and a pointer to the :openxr_ref:`XrSystemId` to the :openxr_ref:`xrGetSystem` function. When the function is called, if successful, :openxr_ref:`XrSystemId` will be non-null.
+Here, we have filled out the :openxr_ref:`XrSystemGetInfo` structure with the desired :openxr_ref:`XrFormFactor` and passed it as a pointer along with the :openxr_ref:`XrInstance` and a pointer to the :openxr_ref:`XrSystemId` to the :openxr_ref:`xrGetSystem` function. After the function is called, if successful, :openxr_ref:`XrSystemId` will be non-null.
 
 With the above code, we have also got the system's properties. We partially filled out a :openxr_ref:`XrSystemProperties` structure and passed it as a pointer along with the :openxr_ref:`XrInstance` and the :openxr_ref:`XrSystemId` to the :openxr_ref:`xrGetSystemProperties` function. This function will fill out the rest of the :openxr_ref:`XrSystemProperties` structure; detailing the vendor's ID, the system's name and the system's graphics and tracking properties.
 
@@ -223,11 +221,11 @@ You can now run the application to check that you have a valid :openxr_ref:`XrIn
 2.2 Creating a Session
 **********************
 
-The next major component of OpenXR that needs to be created in an :openxr_ref:`XrSession`. An :openxr_ref:`XrSession` encapsulates the state of the application from the perspective of OpenXR. When an :openxr_ref:`XrSession` is created, it starts in the :openxr_ref:`XrSessionState` ``XR_SESSION_STATE_IDLE``. It is up to the runtime to provide any updates to the :openxr_ref:`XrSessionState` and for the application to query them and react to them. We will explore this in :ref:`Chapter 2.3<2.3 Polling the Event Loop>`.
+The next major component of OpenXR that needs to be created is an :openxr_ref:`XrSession`. An :openxr_ref:`XrSession` encapsulates the state of the application from the perspective of OpenXR. When an :openxr_ref:`XrSession` is created, it starts in the :openxr_ref:`XrSessionState` ``XR_SESSION_STATE_IDLE``. It is up to the runtime to provide any updates to the :openxr_ref:`XrSessionState` and for the application to query them and react to them. We will explore this in :ref:`Chapter 2.3<2.3 Polling the Event Loop>`.
 
 For now, we are just going to create an :openxr_ref:`XrSession`. At this point, you'll need to select which Graphics API you wish to use. Only one Graphics API can be used with an :openxr_ref:`XrSession`. This tutorial demonstrates how to use D3D11, D3D12, OpenGL, OpenGL ES and Vulkan in conjunction with OpenXR to render graphics to the provided views. Ultimately, you will most likely be bringing your own rendering solution to this tutorial, therefore the code examples provided for the Graphics APIs are `placeholders` for your own code base; demonstrating in this sub-chapter what objects are needed from your Graphics API to create an :openxr_ref:`XrSession`. This tutorial uses polymorphic classes; ``GraphicsAPI_...`` derives from the base ``GraphicsAPI`` class. There are both compile and runtime checks to select the requested Graphics API, and we construct an appropriate derived class through the use of ``std::unique_ptr<>``. 
 
-Update the constructor of the ``OpenXRTutorial`` class, the ``OpenXRTutorial::Run()`` method and also add the definitions of the new methods and the members to their separate private sections. All the new code is highlighted code below.
+Update the constructor of the ``OpenXRTutorial`` class, the ``OpenXRTutorial::Run()`` method, and add the definitions of the new methods and data members to their separate private sections. All the new code is highlighted below.
 
 .. code-block:: cpp
 	:emphasize-lines: 5-9, 19-20, 51-56, 76-78
@@ -236,7 +234,7 @@ Update the constructor of the ``OpenXRTutorial`` class, the ``OpenXRTutorial::Ru
 	public:
 		OpenXRTutorial(GraphicsAPI_Type apiType)
 			: m_apiType(apiType) {
-			if(!CheckGraphicsAPI_TypeIsValidForPlatform(m_apiType)) {
+			if (!CheckGraphicsAPI_TypeIsValidForPlatform(m_apiType)) {
 				std::cout << "ERROR: The provided Graphics API is not valid for this platform." << std::endl;
 				DEBUG_BREAK;
 			}
@@ -384,16 +382,16 @@ For the ``DestroySession()`` method, add the following code:
 
 Above is the code for creating and destroying an :openxr_ref:`XrSession`. :openxr_ref:`xrDestroySession` will destroy the :openxr_ref:`XrSession` when we are finished and shutting down the application. :openxr_ref:`xrCreateSession` takes the :openxr_ref:`XrInstance`, :openxr_ref:`XrSessionCreateInfo` and a :openxr_ref:`XrSession` return. If the function call is successful, :openxr_ref:`xrCreateSession` will return ``XR_SUCCESS`` and ``m_session`` will be non-null. 
 
-In the :openxr_ref:`XrSessionCreateInfo` structure, ``createFlags`` and ``systemId`` are specified, and we need to specify which Graphics API we wish to use. This is achieved via the use of the :openxr_ref:`XrSessionCreateInfo` ``::next`` void pointer. Following the Vulkan style of extensibility, structures for creating objects can be extended to enable extra functionality. In our case, the extension is required and thus :openxr_ref:`XrSessionCreateInfo` ``::next`` can not be a nullptr. That pointer must point to 'exactly one graphics API binding structure (a structure whose name begins with "XrGraphicsBinding")' (`XrSessionCreateInfo(3) Manual Page <https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrSessionCreateInfo.html>`_). We get a pointer to the correct *Graphics Binding* structure by calling ``GraphicsAPI::GetGraphicsBinding();``.
+In the :openxr_ref:`XrSessionCreateInfo` structure we specify the system id we got from :openxr_ref:`xrGetSystem`, we do not set any flags (``createFlags``), and we define which Graphics API we wish to use. The Graphics API is defined via the :openxr_ref:`XrSessionCreateInfo` ``::next`` void pointer. Following the Vulkan style of extensibility, structures for creating objects can be extended to enable extra functionality. In our case, the extension is required and thus :openxr_ref:`XrSessionCreateInfo` ``::next`` can not be a nullptr. That pointer must point to 'exactly one graphics API binding structure (a structure whose name begins with "XrGraphicsBinding")' (`XrSessionCreateInfo(3) Manual Page <https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrSessionCreateInfo.html>`_). We get a pointer to the correct *Graphics Binding* structure by calling ``GraphicsAPI::GetGraphicsBinding();``.
 
 
 **************************
 2.3 Polling the Event Loop
 **************************
 
-OpenXR uses an event-based system to describe changes within the XR system. It's the application's responsibility to poll these events and react to them. The polling of events is done by the function :openxr_ref:`xrPollEvent`. The application should continually call this function throughout its lifetime. Within a single XR frame, the application should continuously call :openxr_ref:`xrPollEvent` until the internal event queue is 'drained'; multiple events can occur across the XR frame and the application needs to handle and respond to each accordingly.
+OpenXR uses an event-based system to describe changes within the XR system. It's the application's responsibility to poll these events and react to them. The polling of events is done by the function :openxr_ref:`xrPollEvent`. The application should call this function on every frame of its lifetime. Within a single XR frame, the application should continuously call :openxr_ref:`xrPollEvent` until the internal event queue is 'drained'; multiple events can occur in an XR frame and the application needs to handle and respond to each accordingly.
 
-Firstly, we will update the class. In the ``OpenXRTutorial::Run()`` method add the highlighted code below. Also, add the highlighted code for the new methods and members in their separate private sections.
+Firstly, we will update the class. In the ``OpenXRTutorial::Run()`` method add the highlighted code below. Also, add the highlighted code for the new methods and data members in their separate private sections.
 
 .. code-block:: cpp
 	:emphasize-lines: 21-27, 68-70, 92
@@ -505,7 +503,7 @@ Copy the following code into the ``PollEvents()`` method:
 	:end-before: XR_DOCS_TAG_END_PollEvents
 	:dedent: 8
 
-Above, we have defined the ``PollEvents()`` method. Here, we use a lambda to call :openxr_ref:`xrPollEvent`. This call will fill in the :openxr_ref:`XrEventDataBuffer` structure that we pass to the function call, which we use later in this method. We also check that returned :openxr_ref:`XrResult` is ``XR_SUCCESS``. Whilst that function returns ``XR_SUCCESS``, there are events for us to process, and therefore we use a while loop to continually check for new events. :openxr_ref:`xrPollEvent` will update the member variable ``type`` and from this, we use a switch statement to select the appropriate code path. Depending on the updated type, we use a ``reinterpret_cast<>()`` to get the actual data that :openxr_ref:`xrPollEvent` returned. In certain cases, we also check that the returned :openxr_ref:`XrSession` matches the one we created.
+In ``PollEvents()`` we use a lambda to call :openxr_ref:`xrPollEvent`. This call will fill in the :openxr_ref:`XrEventDataBuffer` structure that is accessible via the by-reference capture (``[&]``). We also check that the returned :openxr_ref:`XrResult` is ``XR_SUCCESS``. Whilst :openxr_ref:`xrPollEvent` returns ``XR_SUCCESS``, there are events for us to process, and therefore we use a while loop to continually check for new events. :openxr_ref:`xrPollEvent` will update the member variable ``type``, which then determines how we respond to the event. Depending on the updated type, we use a ``reinterpret_cast<>()`` to get the actual data that :openxr_ref:`xrPollEvent` returned. In certain cases, we also check that the returned :openxr_ref:`XrSession` matches the one we created.
 
 The description of the events comes from `2.22.1. Event Polling of the OpenXR specification <https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#_xrpollevent>`_.
 
@@ -523,7 +521,7 @@ The description of the events comes from `2.22.1. Event Polling of the OpenXR sp
 | XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED          | The application has changed its lifecycle state.                               |
 +---------------------------------------------------+--------------------------------------------------------------------------------+
 
-As described in the table above, most events are transparent in their intentions and how the application should react to them. For the ``XR_TYPE_EVENT_DATA_INSTANCE_LOSS_PENDING`` state, the application may want to try re-creating the :openxr_ref:`XrInstance` in a loop, and after the specified ``lossTime``, until it can create a new instance successfully.
+As described in the table above, most events are transparent in their intentions and how the application should react to them. For the ``XR_TYPE_EVENT_DATA_INSTANCE_LOSS_PENDING`` state, after the specified ``lossTime``, the application may want to try re-creating the :openxr_ref:`XrInstance` in a loop until it is sucessful.
 ``XR_TYPE_EVENT_DATA_INTERACTION_PROFILE_CHANGED`` and ``XR_TYPE_EVENT_DATA_REFERENCE_SPACE_CHANGE_PENDING`` are used for updating how the user interacts with the application and whether a new space change has been detected respectively. :openxr_ref:`XrSpace` s are discussed in detail in :ref:`Chapter 3.2.2<3.2.2 Reference Spaces>`
 
 2.3.2 XrSessionState
@@ -559,12 +557,12 @@ Below is a table describing the states of :openxr_ref:`XrSessionState`:
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------+
 | XR_SESSION_STATE_LOSS_PENDING | The runtime is indicating that the current session is no longer valid and should be destroyed. (*)                      |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------+
-| XR_SESSION_STATE_EXITING      | The runtime is requesting that the application to destroy the session, usually from the user's request.                 |
+| XR_SESSION_STATE_EXITING      | The runtime is requesting that the application destroy the session. Usually triggered by a user request.                 |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------+
 
 (*) Applications may wish to re-create objects like :openxr_ref:`XrSystemId` and :openxr_ref:`XrSession` if hardware changes are detected.
 
-Developers should also be aware of the lifecycle of an :openxr_ref:`XrSession`. Certain :openxr_ref:`XrSessionState` s can only lead to certain others under the correct circumstances. Below is a diagram showing the lifecycle of an :openxr_ref:`XrSession` within an OpenXR application.
+Developers should also be aware of the lifecycle of an :openxr_ref:`XrSession`. Certain :openxr_ref:`XrSessionState` s can only lead to others under specific conditions. Below is a diagram showing the lifecycle of an :openxr_ref:`XrSession` within an OpenXR application.
 
 .. figure:: openxr-session-life-cycle.svg
 	:alt: OpenXR Session Life-Cycle
@@ -583,9 +581,9 @@ As the application runs, if the :openxr_ref:`XrSessionState` changes to ``XR_SES
 	:dedent: 16
 	:emphasize-lines: 4
 
-From the code that we copied in :ref:`Chapter 2.3.1 <2.3.1 xrPollEvent>`, we've assigned to :openxr_ref:`XrSessionBeginInfo` ``::primaryViewConfigurationType`` the value of ``XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO``. This specifies the view configuration of the form factor's primary display - For Head Mounted Displays, it is two views (one per eye). For the time being, we have defaulted to ``XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO``. In :ref:`Chapter 3.1.1 <3.1.1 View Configurations>`, we enumerate all the system's view configurations to pick a suitable one.
+The above code was added in :ref:`Chapter 2.3.1 <2.3.1 xrPollEvent>`. We've assigned to :openxr_ref:`XrSessionBeginInfo` ``::primaryViewConfigurationType`` the value of ``XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO``. This specifies the view configuration of the form factor's primary display - For Head Mounted Displays, it is two views (one per eye). For the time being, we have defaulted to ``XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO``. In :ref:`Chapter 3.1.1 <3.1.1 View Configurations>`, we enumerate all the system's view configurations to pick a suitable one.
 
-If the :openxr_ref:`XrSessionState` changes to ``XR_SESSION_STATE_STOPPING``, the application should call :openxr_ref:`xrEndSession`. This means that the runtime has stopped the session either from a user's input or from some other reason, our application should respond by ending the session and freeing any resources. Below is a small excerpt from the code that we copied in :ref:`Chapter 2.3.1 <2.3.1 xrPollEvent>`.
+If the :openxr_ref:`XrSessionState` changes to ``XR_SESSION_STATE_STOPPING``, the application should call :openxr_ref:`xrEndSession`. This means that the runtime has stopped the session either from the user's input or from some other reason, our application should respond by ending the session and freeing any resources. Below is a small excerpt from the code added in :ref:`Chapter 2.3.1 <2.3.1 xrPollEvent>`.
 
 .. literalinclude:: ../Chapter2/main.cpp
 	:language: cpp
@@ -597,9 +595,9 @@ If the :openxr_ref:`XrSessionState` changes to ``XR_SESSION_STATE_STOPPING``, th
 2.4 Summary
 ***********
 
-We have now created an XR application that can begin and stop an :openxr_ref:`XrSession`, next we will look to add graphics to our application!
+We have now created an XR application that can begin and stop an :openxr_ref:`XrSession`. In the next chapter we will add graphics to our application!
 
-Below is a download link to a zip archive for this chapter containing all the C++ and CMake code for all platform and graphics APIs.
+Below is a download link to a zip archive containing this chapter's C++ and CMake code for all platform and graphics APIs combinations.
 
 :git_release:`Chapter2.zip`
 


### PR DESCRIPTION
Reword Chapter 2 OpenXR setup text for clarity. Namely, spell out that when receiving XR_TYPE_EVENT_DATA_INSTANCE_LOSS_PENDING the app should wait for the time period specified in lossTime before attempting to re-create the instance.