### PR TITLE
fix_opengl.cpp

### DIFF
--- a/Chapter6_1_Multiview/Common/GraphicsAPI_OpenGL.cpp
+++ b/Chapter6_1_Multiview/Common/GraphicsAPI_OpenGL.cpp
@@ -418,8 +418,7 @@ GraphicsAPI_OpenGL::GraphicsAPI_OpenGL(XrInstance m_xrInstance, XrSystemId syste
     GLint n = 0;
     glGetIntegerv(GL_NUM_EXTENSIONS, &n);
 
-    PFNGLGETSTRINGIPROC glGetStringi = 0;
-    glGetStringi = (PFNGLGETSTRINGIPROC)wglGetProcAddress("glGetStringi");
+    PFNGLGETSTRINGIPROC glGetStringi = (PFNGLGETSTRINGIPROC)GetExtension("glGetStringi");
 
     const char* foundExtension = nullptr;
     for (GLint i = 0; i < n; i++)


### PR DESCRIPTION
This PR updates Chapter 6 to use the GetExtension function for retrieving OpenGL extensions.
Although GetExtension was already defined for each platform, it wasn't being used in this part — so I updated the code to make use of it.