### PR TITLE
Remove dead code

### DIFF
--- a/Common/GraphicsAPI_Vulkan.cpp
+++ b/Common/GraphicsAPI_Vulkan.cpp
@@ -436,13 +436,6 @@ void *GraphicsAPI_Vulkan::CreateDesktopSwapchain(const SwapchainCreateInfo &swap
     surfaceCI.hinstance = GetModuleHandle(nullptr);
     surfaceCI.hwnd = (HWND)swapchainCI.windowHandle;
     VULKAN_CHECK(vkCreateWin32SurfaceKHR(instance, &surfaceCI, nullptr, &surface), "Failed to create Device.");
-#elif defined(VK_USE_PLATFORM_ANDROID_KHR)
-    VkAndroidSurfaceCreateInfoKHR surfaceCI;
-    surfaceCI.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
-    surfaceCI.pNext = nullptr;
-    surfaceCI.flags = 0;
-    surfaceCI.window = reinterpret_cast<ANativeWindow *>(m_CI.pWindow);
-    VULKAN_CHECK(vkCreateAndroidSurfaceKHR(m_Instance, &surfaceCI, nullptr, &surface), "Failed to create AndroidSurface.");
 #endif
 
     VkBool32 surfaceSupport;


### PR DESCRIPTION
This function is only called from Windows for the self-test. Removing the android path.