### PR TITLE
Use gl_VertexID for OpenGL

### DIFF
--- a/Shaders/VertexShader.glsl
+++ b/Shaders/VertexShader.glsl
@@ -22,7 +22,11 @@ layout(location = 1) out flat vec3 o_Normal;
 layout(location = 2) out flat vec3 o_Color;
 void main() {
     gl_Position = modelViewProj * a_Positions;
+#ifdef VULKAN
     int face = gl_VertexIndex / 6;
+#else
+    int face = gl_VertexID / 6;
+#endif
     o_TexCoord = uvec2(face, 0);
     o_Normal = (model * normals[face]).xyz;
     o_Color = color.rgb;


### PR DESCRIPTION
gl_VertexIndex is only available for vulkan targets, whereas gl_VertexID is only available for opengl.
This fixes the shader compilation error:
```
OpenGL Debug message (2): 0:25(13): error: `gl_VertexIndex' undeclared
```